### PR TITLE
Fix MySQL query placeholders

### DIFF
--- a/backend/src/models/Lead.ts
+++ b/backend/src/models/Lead.ts
@@ -94,16 +94,21 @@ export class LeadModel {
         throw new NotFoundError('Lead not found');
       }
 
-      const result = await pool.query(`
-        UPDATE leads
-        SET status = $1
-        WHERE id = $2
-        RETURNING
-          id, name, email, phone, message, investment_id as "investmentId",
-          submission_date as "submissionDate", status
-      `, [status, id]);
+      await pool.execute(
+        `UPDATE leads SET status = ? WHERE id = ?`,
+        [status, id]
+      );
 
-      return result.rows[0];
+      const [rows] = await pool.execute(
+        `SELECT
+          id, name, email, phone, message, investment_id as investmentId,
+          submission_date as submissionDate, status
+         FROM leads
+         WHERE id = ?`,
+        [id]
+      );
+
+      return (rows as any[])[0];
     } catch (error) {
       if (error instanceof NotFoundError) {
         throw error;
@@ -118,8 +123,8 @@ export class LeadModel {
     }
 
     try {
-      const result = await pool.query('DELETE FROM leads WHERE id = $1', [id]);
-      return result.rowCount > 0;
+      const [result] = await pool.execute('DELETE FROM leads WHERE id = ?', [id]);
+      return (result as any).affectedRows > 0;
     } catch (error) {
       throw new DatabaseError('Failed to delete lead');
     }
@@ -131,8 +136,8 @@ export class LeadModel {
     }
 
     try {
-      const result = await pool.query('SELECT COUNT(*) as count FROM leads');
-      return parseInt(result.rows[0].count);
+      const [rows] = await pool.execute('SELECT COUNT(*) as count FROM leads');
+      return parseInt((rows as any[])[0].count);
     } catch (error) {
       throw new DatabaseError('Failed to count leads');
     }
@@ -140,16 +145,17 @@ export class LeadModel {
 
   static async findByInvestmentId(investmentId: string): Promise<Lead[]> {
     try {
-      const result = await pool.query(`
-        SELECT
-          id, name, email, phone, message, investment_id as "investmentId",
-          submission_date as "submissionDate", status
-        FROM leads
-        WHERE investment_id = $1
-        ORDER BY submission_date DESC
-      `, [investmentId]);
+      const [rows] = await pool.execute(
+        `SELECT
+          id, name, email, phone, message, investment_id as investmentId,
+          submission_date as submissionDate, status
+         FROM leads
+         WHERE investment_id = ?
+         ORDER BY submission_date DESC`,
+        [investmentId]
+      );
 
-      return result.rows;
+      return rows as Lead[];
     } catch (error) {
       throw new DatabaseError('Failed to fetch leads by investment');
     }
@@ -157,11 +163,9 @@ export class LeadModel {
 
   static async getStatusCounts(): Promise<Record<string, number>> {
     try {
-      const result = await pool.query(`
-        SELECT status, COUNT(*) as count
-        FROM leads
-        GROUP BY status
-      `);
+      const [rows] = await pool.execute(
+        `SELECT status, COUNT(*) as count FROM leads GROUP BY status`
+      );
 
       const counts: Record<string, number> = {
         'New': 0,
@@ -170,7 +174,7 @@ export class LeadModel {
         'Rejected': 0
       };
 
-      result.rows.forEach(row => {
+      (rows as any[]).forEach(row => {
         counts[row.status] = parseInt(row.count);
       });
 


### PR DESCRIPTION
## Summary
- use MySQL parameter placeholders in `InvestmentModel`
- use MySQL parameter placeholders in `LeadModel`

## Testing
- `npm run build`
- `npm run backend:build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840067a658c83309d1efc65777a3fce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated all database queries to use MySQL-style parameter placeholders and execution methods, replacing PostgreSQL-specific syntax.
	- Adjusted result handling to align with MySQL driver conventions across investment and lead management features.
	- No changes to public interfaces; all updates are internal and do not affect user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->