### PR TITLE
Enable image uploads for investments

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -121,6 +121,15 @@ RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX_REQUESTS=100
 ```
 
+### File Uploads
+
+```
+MAX_FILE_SIZE=5242880
+UPLOAD_DIR=uploads
+```
+Set `MAX_FILE_SIZE` (in bytes) to control the maximum upload size and
+`UPLOAD_DIR` for the directory where uploaded images are stored.
+
 ## Scripts
 
 - `npm run dev` - Start development server with hot reload

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
         "helmet": "^8.0.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
+        "multer": "^1.4.5-lts.1",
         "mysql2": "^3.14.1",
         "nodemailer": "^6.9.13",
         "uuid": "^11.0.3",
@@ -28,6 +29,7 @@
         "@types/express": "^5.0.0",
         "@types/jsonwebtoken": "^9.0.7",
         "@types/morgan": "^1.9.9",
+        "@types/multer": "^1.4.7",
         "@types/node": "^22.14.0",
         "@types/nodemailer": "^6.4.13",
         "@types/uuid": "^10.0.0",
@@ -565,6 +567,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.13.tgz",
+      "integrity": "sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.15.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
@@ -642,6 +654,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -711,6 +729,23 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -749,6 +784,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -783,6 +833,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -1245,6 +1301,12 @@
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -1435,6 +1497,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -1468,6 +1551,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.2.tgz",
+      "integrity": "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==",
+      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/mysql2": {
       "version": "3.14.1",
@@ -1588,6 +1690,12 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1639,6 +1747,27 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -1843,6 +1972,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1885,6 +2037,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -1915,6 +2073,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -1944,6 +2108,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/zod": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,8 @@
     "mysql2": "^3.14.1",
     "uuid": "^11.0.3",
     "zod": "^3.24.1",
-    "nodemailer": "^6.9.13"
+    "nodemailer": "^6.9.13",
+    "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
@@ -38,7 +39,8 @@
     "@types/uuid": "^10.0.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",
-    "@types/nodemailer": "^6.4.13"
+    "@types/nodemailer": "^6.4.13",
+    "@types/multer": "^1.4.7"
   },
   "keywords": [
     "investment",

--- a/backend/src/middleware/upload.ts
+++ b/backend/src/middleware/upload.ts
@@ -1,0 +1,32 @@
+import multer from 'multer';
+import path from 'path';
+import fs from 'fs';
+
+const uploadDir = process.env.UPLOAD_DIR || 'uploads';
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => {
+    cb(null, uploadDir);
+  },
+  filename: (_req, file, cb) => {
+    const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
+    cb(null, unique + path.extname(file.originalname));
+  }
+});
+
+const fileFilter: multer.Options['fileFilter'] = (_req, file, cb) => {
+  if (file.mimetype.startsWith('image/')) {
+    cb(null, true);
+  } else {
+    cb(new Error('Invalid file type'));
+  }
+};
+
+export const upload = multer({
+  storage,
+  fileFilter,
+  limits: { fileSize: parseInt(process.env.MAX_FILE_SIZE || '5242880') }
+});

--- a/backend/src/routes/investments.ts
+++ b/backend/src/routes/investments.ts
@@ -3,6 +3,7 @@ import rateLimit from 'express-rate-limit';
 import { InvestmentController } from '../controllers/investmentController.js';
 import { authenticate, requireAdmin } from '../middleware/auth.js';
 import { validateBody, validateQuery } from '../middleware/validation.js';
+import { upload } from '../middleware/upload.js';
 import { createInvestmentSchema, updateInvestmentSchema, investmentFiltersSchema } from '../utils/validation.js';
 
 const router = Router();
@@ -33,6 +34,7 @@ router.get('/:id',
 // POST /api/investments - Public endpoint to submit new investments
 router.post('/',
   submitInvestmentLimiter,
+  upload.array('images', 5),
   validateBody(createInvestmentSchema),
   InvestmentController.createInvestment
 );
@@ -41,6 +43,7 @@ router.post('/',
 router.put('/:id',
   authenticate,
   requireAdmin,
+  upload.array('images', 5),
   validateBody(updateInvestmentSchema),
   InvestmentController.updateInvestment
 );

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,6 +4,8 @@ import helmet from 'helmet';
 import morgan from 'morgan';
 import rateLimit from 'express-rate-limit';
 import dotenv from 'dotenv';
+import path from 'path';
+import fs from 'fs';
 
 // Import routes
 import authRoutes from './routes/auth.js';
@@ -31,6 +33,10 @@ if (
 
 const app = express();
 const PORT = process.env.PORT || 3001;
+const uploadDir = process.env.UPLOAD_DIR || 'uploads';
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
 
 // Trust proxy for Railway/production deployment
 if (process.env.NODE_ENV === 'production') {
@@ -91,6 +97,7 @@ app.use(generalLimiter);
 // Body parsing middleware
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
+app.use('/uploads', express.static(path.resolve(uploadDir)));
 
 // Logging middleware
 if (process.env.NODE_ENV === 'development') {

--- a/backend/src/utils/validation.ts
+++ b/backend/src/utils/validation.ts
@@ -28,34 +28,44 @@ export const createInvestmentSchema = z.object({
   title: z.string().min(1).max(255),
   description: z.string().min(1),
   longDescription: z.string().min(1),
-  amountGoal: z.number().positive(),
+  amountGoal: z.coerce.number().positive(),
   currency: z.string().min(3).max(10),
-  images: z.array(z.string().url()),
   category: z.string().min(1).max(100),
   submittedBy: z.string().min(1).max(255),
   submitterEmail: z.string().email(),
   apyRange: z.string().optional(),
-  minInvestment: z.number().positive().optional(),
+  minInvestment: z.coerce.number().positive().optional(),
   term: z.string().optional(),
-  tags: z.array(z.string()).optional()
+  tags: z.preprocess((val) => {
+    if (typeof val === 'string') {
+      return val.split(',').map(t => t.trim()).filter(Boolean);
+    }
+    return val;
+  }, z.array(z.string()).optional()),
+  images: z.array(z.string()).optional()
 });
 
 export const updateInvestmentSchema = z.object({
   title: z.string().min(1).max(255).optional(),
   description: z.string().min(1).optional(),
   longDescription: z.string().min(1).optional(),
-  amountGoal: z.number().positive().optional(),
-  amountRaised: z.number().min(0).optional(),
+  amountGoal: z.coerce.number().positive().optional(),
+  amountRaised: z.coerce.number().min(0).optional(),
   currency: z.string().min(3).max(10).optional(),
-  images: z.array(z.string().url()).optional(),
+  images: z.array(z.string()).optional(),
   category: z.string().min(1).max(100).optional(),
   status: z.nativeEnum(InvestmentStatus).optional(),
   submittedBy: z.string().min(1).max(255).optional(),
   submitterEmail: z.string().email().optional(),
   apyRange: z.string().optional(),
-  minInvestment: z.number().positive().optional(),
+  minInvestment: z.coerce.number().positive().optional(),
   term: z.string().optional(),
-  tags: z.array(z.string()).optional()
+  tags: z.preprocess((val) => {
+    if (typeof val === 'string') {
+      return val.split(',').map(t => t.trim()).filter(Boolean);
+    }
+    return val;
+  }, z.array(z.string()).optional())
 });
 
 // Lead validation schemas

--- a/components/SubmitInvestmentForm.tsx
+++ b/components/SubmitInvestmentForm.tsx
@@ -94,18 +94,13 @@ const SubmitInvestmentForm: React.FC = () => {
     setSubmitStatus(null);
     setFormErrors({});
 
-    const imageUrls = formData.imageFiles 
-      ? Array.from(formData.imageFiles).map(file => URL.createObjectURL(file)) // temporary local URLs
-      : ['https://picsum.photos/seed/default/400/300'];
-
-    // Map formData to the structure expected by createInvestment
     const newInvestmentData = {
       title: formData.title,
       description: formData.description,
       longDescription: formData.longDescription,
       amountGoal: formData.amountGoal,
       currency: formData.currency,
-      images: imageUrls,
+      imageFiles: formData.imageFiles || undefined,
       category: formData.category,
       submittedBy: formData.submitterName, // Map submitterName to submittedBy
       submitterEmail: formData.submitterEmail, // Pass submitterEmail

--- a/pages/admin/AdminInvestmentsPage.tsx
+++ b/pages/admin/AdminInvestmentsPage.tsx
@@ -201,10 +201,8 @@ const AdminInvestmentsPage: React.FC = () => {
         tags: typeof currentInvestment.tags === 'string'
           ? currentInvestment.tags.split(',').map(t => t.trim()).filter(t => t)
           : Array.isArray(currentInvestment.tags) ? currentInvestment.tags : [],
-        // Handle image files - convert to temporary URLs for now (backend integration needed)
-        images: currentInvestment.imageFiles && currentInvestment.imageFiles.length > 0
-          ? Array.from(currentInvestment.imageFiles).map(file => URL.createObjectURL(file))
-          : Array.isArray(currentInvestment.images) ? currentInvestment.images : [],
+        imageFiles: currentInvestment.imageFiles || undefined,
+        images: Array.isArray(currentInvestment.images) ? currentInvestment.images : [],
         // Handle empty email - set to a default if empty for create operations
         submitterEmail: currentInvestment.submitterEmail?.trim() || (isEditing ? currentInvestment.submitterEmail : 'admin@megainvest.com'),
     };
@@ -220,7 +218,7 @@ const AdminInvestmentsPage: React.FC = () => {
         // because `InvestmentFormData` (the type of `currentInvestment`) omits them.
         // Only `id` needs to be destructured out if it's present in `investmentDataForApi`.
         const { id, ...updateData } = investmentDataForApi;
-        await updateInvestment(currentInvestment.id, updateData as Partial<Investment>);
+        await updateInvestment(currentInvestment.id, updateData as any);
       } else {
         // For create, ensure it matches CreateInvestmentData from service
         // The 'id' is already removed. We need to ensure all required fields for create are present.


### PR DESCRIPTION
## Summary
- support image upload storage with multer
- expose uploaded files over `/uploads`
- adjust investment controllers for multipart image data
- handle image files in routes and validation
- update frontend services and forms to send FormData
- document upload environment variables

## Testing
- `npm install`
- `npm run backend:build`

------
https://chatgpt.com/codex/tasks/task_e_686599bf31808330b46191cb0d68ce93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading up to 5 image files when creating or updating investments.
  * Uploaded images are now stored on the server and can be accessed via a public URL.

* **Bug Fixes**
  * Improved form data handling to support file uploads and flexible input for investment fields.

* **Documentation**
  * Updated backend documentation to include new environment variables for file uploads.

* **Chores**
  * Added necessary dependencies for file upload functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->