### PR TITLE
Add backend image upload support

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -71,8 +71,8 @@ The API will be available at `http://localhost:3001`
 ### Investments (`/api/investments`)
 - `GET /` - List investments (public, with filters)
 - `GET /:id` - Get investment by ID (public)
-- `POST /` - Create investment (public, pending admin approval)
-- `PUT /:id` - Update investment (admin only)
+- `POST /` - Create investment (public, pending admin approval, supports `multipart/form-data` with `images` files)
+- `PUT /:id` - Update investment (admin only, supports `multipart/form-data` with `images` files)
 - `DELETE /:id` - Delete investment (admin only)
 
 ### Leads (`/api/leads`)
@@ -119,6 +119,9 @@ FRONTEND_URL=http://localhost:5173
 # Rate Limiting
 RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX_REQUESTS=100
+# File Uploads
+MAX_FILE_SIZE=5242880
+UPLOAD_DIR=uploads
 ```
 
 ## Scripts

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@types/multer": "^2.0.0",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
@@ -17,6 +18,7 @@
         "helmet": "^8.0.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
+        "multer": "^2.0.1",
         "mysql2": "^3.14.1",
         "nodemailer": "^6.9.13",
         "uuid": "^11.0.3",
@@ -471,7 +473,6 @@
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
       "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -482,7 +483,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -502,7 +502,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.2.tgz",
       "integrity": "sha512-BtjL3ZwbCQriyb0DGw+Rt12qAXPiBTPs815lsUvtt1Grk0vLRMZNMUZ741d5rjk+UQOxfDiBZ3dxpX00vSkK3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -514,7 +513,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
       "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -527,7 +525,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
@@ -545,7 +542,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/morgan": {
@@ -565,11 +561,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.0.0.tgz",
+      "integrity": "sha512-C3Z9v9Evij2yST3RSBktxP9STm6OdMc5uR1xF1SGr98uv8dUlAL2hqwrZ3GVB3uyMyiegnscEK6PGtYvNrjTjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.15.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
       "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -589,21 +593,18 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
       "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -614,7 +615,6 @@
       "version": "1.15.7",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
       "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -641,6 +641,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -711,6 +717,23 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -747,6 +770,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -1435,6 +1473,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -1468,6 +1527,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.1.tgz",
+      "integrity": "sha512-Ug8bXeTIUlxurg8xLTEskKShvcKDZALo1THEX5E41pYCD2sCVub5/kIRIGqWNoqV6szyLyQKV6mD4QUrWE5GCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "mkdirp": "^0.5.6",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.18",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      }
     },
     "node_modules/mysql2": {
       "version": "3.14.1",
@@ -1638,6 +1715,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -1843,6 +1934,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1885,6 +1993,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -1903,7 +2017,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -1914,6 +2027,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -1944,6 +2063,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/zod": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,22 +23,24 @@
     "helmet": "^8.0.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
+    "multer": "^2.0.1",
     "mysql2": "^3.14.1",
+    "nodemailer": "^6.9.13",
     "uuid": "^11.0.3",
-    "zod": "^3.24.1",
-    "nodemailer": "^6.9.13"
+    "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@types/multer": "^2.0.0",
     "@types/bcryptjs": "^2.4.6",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.7",
     "@types/morgan": "^1.9.9",
     "@types/node": "^22.14.0",
+    "@types/nodemailer": "^6.4.13",
     "@types/uuid": "^10.0.0",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2",
-    "@types/nodemailer": "^6.4.13"
+    "typescript": "^5.7.2"
   },
   "keywords": [
     "investment",

--- a/backend/src/controllers/investmentController.ts
+++ b/backend/src/controllers/investmentController.ts
@@ -51,7 +51,15 @@ export class InvestmentController {
 
   static async createInvestment(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      const investmentData: CreateInvestmentData = req.body;
+      const files = (req.files as Express.Multer.File[]) || [];
+      const baseUrl = `${req.protocol}://${req.get('host')}`;
+      const uploadDir = process.env.UPLOAD_DIR || 'uploads';
+      const images = files.map(f => `${baseUrl}/${uploadDir}/${f.filename}`);
+
+      const investmentData: CreateInvestmentData = {
+        ...req.body,
+        images
+      };
       const identifier = req.user?.userId ?? req.ip;
       console.log(`New investment submission from ${identifier}`);
       const investment = await InvestmentModel.create(investmentData);
@@ -68,7 +76,15 @@ export class InvestmentController {
   static async updateInvestment(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       const { id } = req.params;
-      const updates = req.body;
+      const files = (req.files as Express.Multer.File[]) || [];
+      const baseUrl = `${req.protocol}://${req.get('host')}`;
+      const uploadDir = process.env.UPLOAD_DIR || 'uploads';
+      const images = files.map(f => `${baseUrl}/${uploadDir}/${f.filename}`);
+
+      const updates = {
+        ...req.body,
+        ...(images.length > 0 ? { images } : {})
+      };
 
       const investment = await InvestmentModel.update(id, updates);
 

--- a/backend/src/middleware/upload.ts
+++ b/backend/src/middleware/upload.ts
@@ -1,0 +1,27 @@
+import multer from 'multer';
+import fs from 'fs';
+import path from 'path';
+
+const uploadDir = process.env.UPLOAD_DIR || 'uploads';
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => {
+    cb(null, uploadDir);
+  },
+  filename: (_req, file, cb) => {
+    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1e9);
+    cb(null, uniqueSuffix + path.extname(file.originalname));
+  }
+});
+
+const maxSize = parseInt(process.env.MAX_FILE_SIZE || '5242880'); // default 5MB
+
+const upload = multer({
+  storage,
+  limits: { fileSize: maxSize }
+});
+
+export default upload;

--- a/backend/src/routes/investments.ts
+++ b/backend/src/routes/investments.ts
@@ -3,6 +3,7 @@ import rateLimit from 'express-rate-limit';
 import { InvestmentController } from '../controllers/investmentController.js';
 import { authenticate, requireAdmin } from '../middleware/auth.js';
 import { validateBody, validateQuery } from '../middleware/validation.js';
+import upload from '../middleware/upload.js';
 import { createInvestmentSchema, updateInvestmentSchema, investmentFiltersSchema } from '../utils/validation.js';
 
 const router = Router();
@@ -33,6 +34,7 @@ router.get('/:id',
 // POST /api/investments - Public endpoint to submit new investments
 router.post('/',
   submitInvestmentLimiter,
+  upload.array('images', 5),
   validateBody(createInvestmentSchema),
   InvestmentController.createInvestment
 );
@@ -41,6 +43,7 @@ router.post('/',
 router.put('/:id',
   authenticate,
   requireAdmin,
+  upload.array('images', 5),
   validateBody(updateInvestmentSchema),
   InvestmentController.updateInvestment
 );

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -31,6 +31,7 @@ if (
 
 const app = express();
 const PORT = process.env.PORT || 3001;
+const uploadDir = process.env.UPLOAD_DIR || 'uploads';
 
 // Trust proxy for Railway/production deployment
 if (process.env.NODE_ENV === 'production') {
@@ -91,6 +92,9 @@ app.use(generalLimiter);
 // Body parsing middleware
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
+
+// Serve uploaded files
+app.use(`/${uploadDir}`, express.static(uploadDir));
 
 // Logging middleware
 if (process.env.NODE_ENV === 'development') {

--- a/backend/src/utils/validation.ts
+++ b/backend/src/utils/validation.ts
@@ -30,7 +30,7 @@ export const createInvestmentSchema = z.object({
   longDescription: z.string().min(1),
   amountGoal: z.number().positive(),
   currency: z.string().min(3).max(10),
-  images: z.array(z.string().url()),
+  images: z.array(z.string().url()).optional(),
   category: z.string().min(1).max(100),
   submittedBy: z.string().min(1).max(255),
   submitterEmail: z.string().email(),


### PR DESCRIPTION
## Summary
- install `multer` with TypeScript types
- create `upload` middleware for saving files
- expose the upload directory via `express.static`
- allow file uploads on investment create/update routes
- store uploaded image URLs in investment controller
- document upload environment variables and multipart endpoints

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68659e598dc08330bf4d2d310db5027f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading up to 5 images when creating or updating investments.
  * Uploaded images are now accessible via direct URLs.

* **Bug Fixes**
  * Resolved duplicate and redundant dependency entries in backend dependencies.

* **Documentation**
  * Updated backend API documentation to reflect new file upload capabilities and related environment variables.

* **Chores**
  * Added new dependencies to support file uploads and email functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->