### PR TITLE
Implement multipart investment submission

### DIFF
--- a/pages/admin/AdminInvestmentsPage.tsx
+++ b/pages/admin/AdminInvestmentsPage.tsx
@@ -1,7 +1,7 @@
 
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { Investment, InvestmentStatus } from '../../types';
-import { getInvestments, createInvestment, updateInvestment, deleteInvestment } from '../../services/investmentService';
+import { getInvestments, createInvestment, createInvestmentWithFiles, updateInvestment, deleteInvestment } from '../../services/investmentService';
 import Button from '../../components/Button';
 import Modal from '../../components/Modal';
 import LoadingSpinner from '../../components/LoadingSpinner';
@@ -225,7 +225,11 @@ const AdminInvestmentsPage: React.FC = () => {
         // For create, ensure it matches CreateInvestmentData from service
         // The 'id' is already removed. We need to ensure all required fields for create are present.
         const { id, ...createData } = investmentDataForApi;
-        await createInvestment(createData as any); // Cast if type mismatch with service due to Omit differences
+        if (currentInvestment.imageFiles && currentInvestment.imageFiles.length > 0) {
+          await createInvestmentWithFiles(createData as any, currentInvestment.imageFiles);
+        } else {
+          await createInvestment(createData as any); // Cast if type mismatch with service due to Omit differences
+        }
       }
       fetchInvestments(); 
       handleCloseModal();

--- a/services/investmentService.ts
+++ b/services/investmentService.ts
@@ -39,6 +39,27 @@ export const createInvestment = async (investmentData: CreateInvestmentData): Pr
   return apiClient.post<Investment>('/investments', investmentData);
 };
 
+export const createInvestmentWithFiles = async (
+  investmentData: Omit<CreateInvestmentData, 'images'>,
+  imageFiles: FileList
+): Promise<Investment> => {
+  const formData = new FormData();
+
+  Object.entries(investmentData).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      value.forEach(v => formData.append(key, String(v)));
+    } else if (value !== undefined && value !== null) {
+      formData.append(key, String(value));
+    }
+  });
+
+  Array.from(imageFiles).forEach(file => {
+    formData.append('images', file);
+  });
+
+  return apiClient.post<Investment>('/investments', formData);
+};
+
 export const updateInvestment = async (investmentId: string, updates: Partial<Investment>): Promise<Investment | null> => {
   return apiClient.put<Investment>(`/investments/${investmentId}`, updates);
 };


### PR DESCRIPTION
## Summary
- allow api client to send multipart requests when body is FormData
- add createInvestmentWithFiles helper and send multipart forms
- use new helper in submit and admin pages when uploading images

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68659f6b41dc8330b8704710ce046283