### PR TITLE
Add backend uploads ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 backend/.env
 backend/fly.toml
 RENDER_DEPLOYMENT_GUIDE.md
+backend/uploads/


### PR DESCRIPTION
## Summary
- prevent accidental binary uploads by ignoring `backend/uploads/`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68659f6f9cb48330ba32005cf5097efc