### PR TITLE
Document file upload env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ DB_HOST=localhost
 DB_USER=root
 DB_PASSWORD=your-password
 DB_NAME=megainvest
+MAX_FILE_SIZE=5242880  # maximum upload size in bytes
+UPLOAD_DIR=uploads    # directory for storing uploaded files
+```
+
+Create the uploads directory before running the backend if you plan to allow file uploads:
+```bash
+mkdir -p backend/uploads
 ```
 
 ### Database Setup

--- a/backend/README.md
+++ b/backend/README.md
@@ -54,7 +54,12 @@ npm run db:migrate  # Create tables
 npm run db:seed     # Add sample data
 ```
 
-4. Start the development server:
+4. Create the uploads directory (required if you enable file uploads):
+```bash
+mkdir -p uploads
+```
+
+5. Start the development server:
 ```bash
 npm run dev
 ```
@@ -119,6 +124,10 @@ FRONTEND_URL=http://localhost:5173
 # Rate Limiting
 RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX_REQUESTS=100
+
+# File Uploads
+MAX_FILE_SIZE=5242880  # Maximum upload size in bytes (5MB default)
+UPLOAD_DIR=uploads    # Directory where uploaded files are stored
 ```
 
 ## Scripts


### PR DESCRIPTION
## Summary
- document `MAX_FILE_SIZE` and `UPLOAD_DIR` in backend README
- add setup instructions for creating the uploads directory
- mention the file upload env vars in the root README

## Testing
- `npm run deploy:check` *(fails: Not all services updated)*

------
https://chatgpt.com/codex/tasks/task_e_68659f7136e4833080b5e16175dab0e6